### PR TITLE
Add admin order management

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react"
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <div className="container mx-auto px-4 py-8">{children}</div>
+}

--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { useOrderStore } from "@/lib/order-store"
+import { useAuthStore } from "@/lib/auth-store"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+
+export default function OrderDetail({ params }: { params: { id: string } }) {
+  const { isAuthenticated } = useAuthStore()
+  const { orders, updateOrder, markFulfilled, markShipped } = useOrderStore()
+  const router = useRouter()
+  const order = orders.find((o) => o.id === Number(params.id))
+  const [customer, setCustomer] = useState(order?.customer || "")
+
+  if (!isAuthenticated) {
+    return <div className="p-6">Please login to access admin.</div>
+  }
+
+  if (!order) {
+    return <div className="p-6">Order not found.</div>
+  }
+
+  const handleSave = () => {
+    updateOrder(order.id, { customer })
+    router.push("/admin/orders")
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-[#3B7A8B]">Edit Order #{order.id}</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Order Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <label className="mb-2 block text-sm font-medium">Customer</label>
+            <Input value={customer} onChange={(e) => setCustomer(e.target.value)} />
+          </div>
+          <div>Status: {order.status}</div>
+          <div>Total: ${order.total.toFixed(2)}</div>
+          <div className="space-x-2">
+            {order.status !== "fulfilled" && (
+              <Button size="sm" onClick={() => markFulfilled(order.id)}>
+                Mark Fulfilled
+              </Button>
+            )}
+            {order.status === "fulfilled" && (
+              <Button size="sm" onClick={() => markShipped(order.id)}>
+                Mark Shipped
+              </Button>
+            )}
+          </div>
+          <Button onClick={handleSave} className="bg-[#3B7A8B] hover:bg-[#3B7A8B]/90">
+            Save
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import Link from "next/link"
+import { useOrderStore } from "@/lib/order-store"
+import { useAuthStore } from "@/lib/auth-store"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+
+export default function OrdersPage() {
+  const { isAuthenticated } = useAuthStore()
+  const { orders, markFulfilled, markShipped } = useOrderStore()
+
+  if (!isAuthenticated) {
+    return <div className="p-6">Please login to access admin.</div>
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-[#3B7A8B]">Orders</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>Customer</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Total</TableHead>
+            <TableHead></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {orders.map((order) => (
+            <TableRow key={order.id}>
+              <TableCell>
+                <Link href={`/admin/orders/${order.id}`}>#{order.id}</Link>
+              </TableCell>
+              <TableCell>{order.customer}</TableCell>
+              <TableCell>{order.status}</TableCell>
+              <TableCell>${order.total.toFixed(2)}</TableCell>
+              <TableCell className="space-x-2">
+                {order.status !== "fulfilled" && (
+                  <Button size="sm" onClick={() => markFulfilled(order.id)}>
+                    Fulfill
+                  </Button>
+                )}
+                {order.status === "fulfilled" && (
+                  <Button size="sm" onClick={() => markShipped(order.id)}>
+                    Ship
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { useAuthStore } from "@/lib/auth-store"
+import { useOrderStore } from "@/lib/order-store"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+export default function AdminPage() {
+  const { isAuthenticated, login, logout } = useAuthStore()
+  const { orders } = useOrderStore()
+  const [username, setUsername] = useState("")
+  const [password, setPassword] = useState("")
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault()
+    login(username, password)
+  }
+
+  const totalSales = orders.reduce((sum, order) => sum + order.total, 0)
+
+  if (!isAuthenticated) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Card className="w-full max-w-sm">
+          <CardHeader>
+            <CardTitle>Admin Login</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleLogin} className="space-y-4">
+              <Input
+                placeholder="Username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+              />
+              <Input
+                type="password"
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <Button
+                type="submit"
+                className="w-full bg-[#3B7A8B] hover:bg-[#3B7A8B]/90"
+              >
+                Login
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold text-[#3B7A8B]">Admin Dashboard</h1>
+        <Button variant="outline" onClick={logout}>
+          Logout
+        </Button>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Metrics</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xl font-semibold">
+            Total Sales: ${totalSales.toFixed(2)}
+          </p>
+        </CardContent>
+      </Card>
+      <Link href="/admin/orders">
+        <Button className="bg-[#3B7A8B] hover:bg-[#3B7A8B]/90">View Orders</Button>
+      </Link>
+    </div>
+  )
+}

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -1,0 +1,29 @@
+"use client"
+
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+interface AuthState {
+  isAuthenticated: boolean
+  login: (username: string, password: string) => boolean
+  logout: () => void
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      isAuthenticated: false,
+      login: (username, password) => {
+        if (username === "admin" && password === "password") {
+          set({ isAuthenticated: true })
+          return true
+        }
+        return false
+      },
+      logout: () => set({ isAuthenticated: false }),
+    }),
+    {
+      name: "magtowel-auth",
+    },
+  ),
+)

--- a/lib/order-store.ts
+++ b/lib/order-store.ts
@@ -1,0 +1,75 @@
+"use client"
+
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+export type OrderStatus = "pending" | "fulfilled" | "shipped"
+
+export interface OrderItem {
+  id: number
+  name: string
+  price: number
+  quantity: number
+}
+
+export interface Order {
+  id: number
+  customer: string
+  total: number
+  status: OrderStatus
+  items: OrderItem[]
+}
+
+interface OrderState {
+  orders: Order[]
+  markFulfilled: (id: number) => void
+  markShipped: (id: number) => void
+  updateOrder: (id: number, data: Partial<Order>) => void
+}
+
+export const useOrderStore = create<OrderState>()(
+  persist(
+    (set) => ({
+      orders: [
+        {
+          id: 1,
+          customer: "John Doe",
+          total: 69.98,
+          status: "pending" as OrderStatus,
+          items: [
+            { id: 1, name: "Classic MagTowel", price: 29.99, quantity: 1 },
+            { id: 2, name: "Premium MagTowel", price: 39.99, quantity: 1 },
+          ],
+        },
+        {
+          id: 2,
+          customer: "Sarah Lee",
+          total: 39.99,
+          status: "pending" as OrderStatus,
+          items: [
+            { id: 2, name: "Premium MagTowel", price: 39.99, quantity: 1 },
+          ],
+        },
+      ],
+      markFulfilled: (id) =>
+        set((state) => ({
+          orders: state.orders.map((o) =>
+            o.id === id ? { ...o, status: "fulfilled" } : o,
+          ),
+        })),
+      markShipped: (id) =>
+        set((state) => ({
+          orders: state.orders.map((o) =>
+            o.id === id ? { ...o, status: "shipped" } : o,
+          ),
+        })),
+      updateOrder: (id, data) =>
+        set((state) => ({
+          orders: state.orders.map((o) => (o.id === id ? { ...o, ...data } : o)),
+        })),
+    }),
+    {
+      name: "magtowel-orders",
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- implement simple auth and order stores
- create `/admin` with login and metrics
- add `/admin/orders` list view
- allow order updates via `/admin/orders/[id]`

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*