### PR TITLE
Add auth pages and API routes

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,5 @@
+import NextAuth from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+const handler = NextAuth(authOptions)
+export { handler as GET, handler as POST }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { hash } from 'bcryptjs'
+
+export async function POST(request: Request) {
+  try {
+    const { name, email, password } = await request.json()
+    if (!email || !password) {
+      return NextResponse.json({ message: 'Missing fields' }, { status: 400 })
+    }
+    const existing = await prisma.user.findUnique({ where: { email } })
+    if (existing) {
+      return NextResponse.json({ message: 'User already exists' }, { status: 400 })
+    }
+    const hashed = await hash(password, 10)
+    const user = await prisma.user.create({ data: { name, email, password: hashed } })
+    return NextResponse.json({ id: user.id, email: user.email })
+  } catch (err) {
+    return NextResponse.json({ message: 'Server error' }, { status: 500 })
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import Header from "@/components/layout/header"
 import Footer from "@/components/layout/footer"
 import { Toaster } from "@/components/ui/toaster"
 import { SearchProvider } from "@/lib/search-context"
+import { SessionProvider } from "next-auth/react"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -34,16 +35,18 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable} ${montserrat.variable}`}>
       <body className="font-sans">
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-          <SearchProvider>
-            <div className="flex min-h-screen flex-col">
-              <Header />
-              <div className="flex-1">{children}</div>
-              <Footer />
-              <Toaster />
-            </div>
-          </SearchProvider>
-        </ThemeProvider>
+        <SessionProvider>
+          <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+            <SearchProvider>
+              <div className="flex min-h-screen flex-col">
+                <Header />
+                <div className="flex-1">{children}</div>
+                <Footer />
+                <Toaster />
+              </div>
+            </SearchProvider>
+          </ThemeProvider>
+        </SessionProvider>
       </body>
     </html>
   )

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useState } from 'react'
+import { signIn } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import Link from 'next/link'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await signIn('credentials', {
+      redirect: false,
+      email,
+      password,
+    })
+    if (res?.error) {
+      setError('Invalid email or password')
+    } else {
+      router.push('/')
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col">
+      <div className="container mx-auto px-4 py-8 md:px-6">
+        <h1 className="mb-6 text-3xl font-bold text-[#3B7A8B]">Login</h1>
+        <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <Input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <Button type="submit" className="bg-[#E6C288] text-[#3B7A8B] hover:bg-[#E6C288]/90">Login</Button>
+        </form>
+        <p className="mt-4 text-sm">
+          Don&apos;t have an account?{' '}
+          <Link href="/signup" className="text-[#3B7A8B] underline">
+            Sign up
+          </Link>
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import Link from 'next/link'
+
+export default function SignupPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, password }),
+    })
+    if (!res.ok) {
+      const data = await res.json()
+      setError(data.message || 'Failed to sign up')
+      return
+    }
+    router.push('/login')
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col">
+      <div className="container mx-auto px-4 py-8 md:px-6">
+        <h1 className="mb-6 text-3xl font-bold text-[#3B7A8B]">Sign Up</h1>
+        <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+          <Input
+            type="text"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <Input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <Button type="submit" className="bg-[#E6C288] text-[#3B7A8B] hover:bg-[#E6C288]/90">Create Account</Button>
+        </form>
+        <p className="mt-4 text-sm">
+          Already have an account?{' '}
+          <Link href="/login" className="text-[#3B7A8B] underline">
+            Log in
+          </Link>
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { usePathname } from "next/navigation"
 import { Menu, ShoppingCart, Search, User, Heart } from "lucide-react"
+import { useSession } from "next-auth/react"
 
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetClose, SheetTrigger } from "@/components/ui/sheet"
@@ -18,6 +19,7 @@ import { useSearch } from "@/lib/search-context"
 export default function Header() {
   const pathname = usePathname()
   const isMobile = useMobile()
+  const { data: session } = useSession()
   const [isScrolled, setIsScrolled] = useState(false)
   const cartItems = useCartStore((state) => state.items)
   const wishlistItems = useWishlistStore((state) => state.items)
@@ -107,7 +109,7 @@ export default function Header() {
               <Search className="h-5 w-5" />
               <span className="sr-only">Search</span>
             </Button>
-            <Link href="/account">
+            <Link href={session ? "/account" : "/login"} className="flex items-center space-x-2">
               <Button
                 variant="ghost"
                 size="icon"
@@ -116,6 +118,9 @@ export default function Header() {
                 <User className="h-5 w-5" />
                 <span className="sr-only">Account</span>
               </Button>
+              {session?.user?.name && (
+                <span className="hidden text-sm font-medium md:block">{session.user.name}</span>
+              )}
             </Link>
             <Link href="/wishlist" className="relative">
               <Button
@@ -217,11 +222,11 @@ export default function Header() {
                     </div>
                     <SheetClose asChild>
                       <Link
-                        href="/account"
+                        href={session ? "/account" : "/login"}
                         className="flex items-center py-2 text-base font-medium text-secondary transition-colors hover:text-[#3B7A8B]"
                       >
                         <User className="mr-3 h-5 w-5" />
-                        <span>Account</span>
+                        <span>{session?.user?.name ?? 'Account'}</span>
                       </Link>
                     </SheetClose>
                     <SheetClose asChild>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,30 @@
+import { PrismaAdapter } from '@next-auth/prisma-adapter'
+import CredentialsProvider from 'next-auth/providers/credentials'
+import type { NextAuthOptions } from 'next-auth'
+import { prisma } from './prisma'
+import { compare } from 'bcryptjs'
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: 'jwt' },
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null
+        const user = await prisma.user.findUnique({ where: { email: credentials.email } })
+        if (!user) return null
+        const isValid = await compare(credentials.password, user.password)
+        if (!isValid) return null
+        return { id: user.id.toString(), name: user.name, email: user.email }
+      },
+    }),
+  ],
+  pages: {
+    signIn: '/login',
+  },
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({ log: ['query'] })
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -55,6 +56,10 @@
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",
     "sonner": "^1.7.1",
+    "@prisma/client": "^5.14.0",
+    "bcryptjs": "^2.4.3",
+    "next-auth": "^4.22.1",
+    "@next-auth/prisma-adapter": "^1.0.7",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "use-sync-external-store": "latest",
@@ -63,6 +68,7 @@
     "zustand": "latest"
   },
   "devDependencies": {
+    "prisma": "^5.14.0",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  name      String?
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}


### PR DESCRIPTION
## Summary
- add login and signup pages
- implement NextAuth route and signup API
- setup Prisma schema and client
- wrap app in SessionProvider
- show user name in header when logged in
- add auth-related dependencies
- include postinstall script to generate Prisma client

## Testing
- `npm run build` *(fails: next not found)*
